### PR TITLE
Fix missing file extension in calls to ExecuteTemplate to match map

### DIFF
--- a/_posts/2014-06-10-approximating-html-template-inheritance.md
+++ b/_posts/2014-06-10-approximating-html-template-inheritance.md
@@ -107,7 +107,7 @@ func renderTemplate(w http.ResponseWriter, name string, data map[string]interfac
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	return tmpl.ExecuteTemplate(w, "base", data)
+	return tmpl.ExecuteTemplate(w, "base.tmpl", data)
 }
 
 ```
@@ -146,7 +146,7 @@ func renderTemplate(w http.ResponseWriter, name string, data map[string]interfac
 	buf := bufpool.Get()
 	defer bufpool.Put(buf)
     
-	err := tmpl.ExecuteTemplate(buf, "base", data)
+	err := tmpl.ExecuteTemplate(buf, "base.tmpl", data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Usage of the code as is does not work directly. The call to ExecuteTemplate passes in the file name minus the extension. This is an issue as the templates map uses the filename with extension as the key.