### PR TITLE
ci: keep Bonk on personal account endpoint

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
+          oidc_base_url: https://ask-bonk.silverlock.workers.dev/auth
           model: opencode/claude-opus-4-6
           mentions: "/bonk,@ask-bonk"
           permissions: write


### PR DESCRIPTION
This explicitly keeps Bonk on the personal Cloudflare endpoint now that the shared action defaults to the production account.